### PR TITLE
Adjust `simulator` option value

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,1 @@
+"prettier-config-standard"

--- a/bundle.js
+++ b/bundle.js
@@ -21,7 +21,7 @@ async function bundle(entry) {
     {
       platform,
       arch,
-      simulator,
+      simulator: simulator !== '0',
       resolve: resolve.bare,
       builtins: builtins !== '0' ? require(builtins) : [],
       linked: linked !== '0'

--- a/bundle.js
+++ b/bundle.js
@@ -7,30 +7,28 @@ const fs = require('bare-pack/fs')
 const compile = require('bare-bundle-compile')
 const includeStatic = require('include-static')
 
-const [
-  entry,
-  out,
-  builtins,
-  linked,
-  platform,
-  arch,
-  simulator
-] = process.argv.slice(2)
+const [entry, out, builtins, linked, platform, arch, simulator] =
+  process.argv.slice(2)
 
 bundle(entry)
 
-async function bundle (entry) {
+async function bundle(entry) {
   const format = defaultFormat(out)
   const encoding = 'utf8'
 
-  let bundle = await pack(pathToFileURL(entry), {
-    platform,
-    arch,
-    simulator,
-    resolve: resolve.bare,
-    builtins: builtins !== '0' ? require(builtins) : [],
-    linked: linked !== '0'
-  }, fs.readModule, fs.listPrefix)
+  let bundle = await pack(
+    pathToFileURL(entry),
+    {
+      platform,
+      arch,
+      simulator,
+      resolve: resolve.bare,
+      builtins: builtins !== '0' ? require(builtins) : [],
+      linked: linked !== '0'
+    },
+    fs.readModule,
+    fs.listPrefix
+  )
 
   bundle = bundle.unmount(pathToFileURL('.'))
 
@@ -71,9 +69,10 @@ async function bundle (entry) {
   await fs.writeFile(pathToFileURL(out), data)
 }
 
-function defaultFormat (out) {
+function defaultFormat(out) {
   if (typeof out !== 'string') return 'bundle'
-  if (out.endsWith('.bundle.js') || out.endsWith('.bundle.cjs')) return 'bundle.cjs'
+  if (out.endsWith('.bundle.js') || out.endsWith('.bundle.cjs'))
+    return 'bundle.cjs'
   if (out.endsWith('.bundle.mjs')) return 'bundle.mjs'
   if (out.endsWith('.bundle.json')) return 'bundle.json'
   if (out.endsWith('.bundle.h')) return 'bundle.h'
@@ -82,9 +81,10 @@ function defaultFormat (out) {
   return 'bundle'
 }
 
-function defaultName (out) {
+function defaultName(out) {
   if (out === null) return 'bundle'
-  return path.basename(out)
+  return path
+    .basename(out)
     .replace(/\.h$/, '')
     .replace(/[-.]+/g, '_')
     .toLowerCase()

--- a/dependencies.js
+++ b/dependencies.js
@@ -16,7 +16,7 @@ async function dependencies(entry) {
     {
       platform,
       arch,
-      simulator,
+      simulator: simulator !== '0',
       resolve: resolve.bare,
       builtins: builtins === '0' ? [] : require(builtins),
       linked: linked !== '0'

--- a/dependencies.js
+++ b/dependencies.js
@@ -5,34 +5,34 @@ const { resolve } = require('bare-module-traverse')
 const pack = require('bare-pack')
 const fs = require('bare-pack/fs')
 
-const [
-  entry,
-  out,
-  builtins,
-  linked,
-  platform,
-  arch,
-  simulator
-] = process.argv.slice(2)
+const [entry, out, builtins, linked, platform, arch, simulator] =
+  process.argv.slice(2)
 
 dependencies(entry)
 
-async function dependencies (entry) {
-  let bundle = await pack(pathToFileURL(entry), {
-    platform,
-    arch,
-    simulator,
-    resolve: resolve.bare,
-    builtins: builtins === '0' ? [] : require(builtins),
-    linked: linked !== '0'
-  }, fs.readModule, fs.listPrefix)
+async function dependencies(entry) {
+  let bundle = await pack(
+    pathToFileURL(entry),
+    {
+      platform,
+      arch,
+      simulator,
+      resolve: resolve.bare,
+      builtins: builtins === '0' ? [] : require(builtins),
+      linked: linked !== '0'
+    },
+    fs.readModule,
+    fs.listPrefix
+  )
 
   bundle = bundle.unmount(pathToFileURL('.'))
 
-  const result = Object
-    .keys(bundle.files)
+  const result = Object.keys(bundle.files)
     .map((file) => path.resolve('.' + file))
     .sort()
 
-  await fs.writeFile(pathToFileURL(`${out}.d`), `${path.resolve(out)}: ${result.join(' ')}\n`)
+  await fs.writeFile(
+    pathToFileURL(`${out}.d`),
+    `${path.resolve(out)}: ${result.join(' ')}\n`
+  )
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "include-static": "^1.1.0"
   },
   "devDependencies": {
-    "standard": "^17.1.2"
+    "prettier": "^3.5.3",
+    "prettier-config-standard": "^7.0.0"
   }
 }


### PR DESCRIPTION
Although `simulator` is a boolean value, it is currently propagated to `bare-pack` and later to `bare-module-traverse` as a string like '0', being misunderstood as a truthy value. 

I noticed that after hitting this context on `bare-module-traverse:
```js
host: `${platform}-${arch}${simulator ? '-simulator' : ''}`
```